### PR TITLE
Handle irrelevant answers better

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -83,12 +83,17 @@ def register_routes(app):
             if not texto or not pregunta:
                 continue
 
-            sentimiento = analyze_sentiment(texto)
+            sentimiento = analyze_sentiment(texto, pregunta)
             if sentimiento == "Error":
                 sentimiento = "nulo"
                 polaridad = 0.0
             else:
-                polaridad = 0.5 if sentimiento == "positivo" else -0.5 if sentimiento == "negativo" else 0.0
+                if sentimiento == "positivo":
+                    polaridad = 0.5
+                elif sentimiento == "negativo":
+                    polaridad = -0.5
+                else:
+                    polaridad = 0.0
 
             add_comment(email, pregunta, texto, sentimiento, polaridad)
 


### PR DESCRIPTION
## Summary
- tighten up prompt to label mixed answers as neutral
- simplify polarity calculation for answers
- map unexpected Gemini results to neutral

## Testing
- `python -m py_compile backend/app/services/sentiment_analysis.py backend/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_684ca2f4cecc832ca148dfa8dfd6f51f